### PR TITLE
ci: update secrets & vars

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,11 +80,11 @@ jobs:
           popd && rm -rf bats-core
       - name: Install criu
         env:
-          CLOUDSMITH_ENTITLEMENT_TOKEN_CRIU: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_CRIU }}
+          CLOUDSMITH_ENTITLEMENT_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN }}
         run: |
           TAG=latest
           sudo apt -qq install libnet1 libprotobuf-c1
-          curl -1sLf -O https://dl.cloudsmith.io/$CLOUDSMITH_ENTITLEMENT_TOKEN_CRIU/cedana/criu/raw/versions/$TAG/criu
+          curl -1sLf -O https://dl.cloudsmith.io/$CLOUDSMITH_ENTITLEMENT_TOKEN/cedana/criu/raw/versions/$TAG/criu
           chmod +x criu
           sudo cp criu /usr/local/sbin/
           echo "installed $(whereis criu)"


### PR DESCRIPTION
Secrets and vars were cleaned up, and many common ones moved to org level. This PR updates the CI to use the new secrets and vars.