### PR TITLE
Set version in binary from GitHub tag using Makefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Build cedana-image-streamer
       run: |
-        cargo build --release --bin cedana-image-streamer
+        make build
+        echo $(target/release/cedana-image-streamer --version)
     - name: Persist cedana-image-streamer
       id: persist-cedana-image-streamer
       uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "image-streamer"
-version = "1.0.0"
+name = "cedana-image-streamer"
+version = "0.0.0" # replaced by Makefile
 authors = ["Nicolas Viennot <Nicolas.Viennot@twosigma.com>", "Liana Koleva <liana@cedana.ai>"]
 description = "Capture and extract CRIU + Cedana images via UNIX pipes"
 edition = "2021"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+ifndef VERBOSE
+.SILENT:
+endif
+
+BINARY=cedana-image-streamer
+BUILD_SOURCES=Cargo.toml $(shell find . -name '*.proto' -o -name '*.rs')
+OUT_DIR=$(PWD)/target/release
+SUDO=sudo -E env "PATH=$(PATH)"
+VERSION=$(shell git describe --tags --always | sed 's/^v//')
+
+all: install
+
+build: $(OUT_DIR)/$(BINARY)
+
+$(OUT_DIR)/$(BINARY): $(BUILD_SOURCES)
+	sed -i "s/^version = \".*\"/version = \"$(VERSION)\"/" Cargo.toml
+	cargo build --release --bin $(BINARY)
+
+install: $(OUT_DIR)/$(BINARY)
+	$(SUDO) rm -f /usr/local/bin/$(BINARY)
+	$(SUDO) cp $(OUT_DIR)/$(BINARY) /usr/local/bin
+
+reset:
+	$(SUDO) rm -f /usr/local/bin/$(BINARY)
+	rm -f $(OUT_DIR)/$(BINARY)

--- a/src/comm.rs
+++ b/src/comm.rs
@@ -5,7 +5,7 @@ use aws_sdk_s3::{
     types::{CompletedMultipartUpload, CompletedPart},
 };
 use crossbeam_utils::Backoff;
-use image_streamer::{
+use cedana_image_streamer::{
     capture::capture,
     extract::{extract, serve},
     unix_pipe::UnixPipe,


### PR DESCRIPTION
Running `make build` builds a GitHub tag-aware versioned executable. Also included general Makefile functionality.

Example:
<img width="349" alt="example" src="https://github.com/user-attachments/assets/4c03472d-6717-43fb-a235-5a0b9e316b4f" />
