### PR TITLE
ci: Reuse regression tests from daemon

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,7 @@ jobs:
 
   daemon-tests:
     name: Daemon
-    uses: cedana/cedana/.github/workflows/pr.yml
+    uses: cedana/cedana/.github/workflows/pr.yml@main
     needs: build
     permissions:
       contents: "read"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
           path: target/release/cedana-image-streamer
 
   clippy_check:
-    name: Check
+    name: Clippy Check
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -57,7 +57,7 @@ jobs:
 
   daemon-tests:
     name: Daemon
-    uses: cedana/cedana/.github/workflows/pr.yml@feature/ced-1011-reuse-regression-tests-in-cedana-gpu
+    uses: cedana/cedana/.github/workflows/pr.yml
     needs: build
     permissions:
       contents: "read"
@@ -65,7 +65,7 @@ jobs:
       id-token: "write"
       pull-requests: "write"
     with:
-      ref: feature/ced-1011-reuse-regression-tests-in-cedana-gpu
+      ref: main
       debug_build: ${{ startsWith(github.event_name, 'workflow') && inputs.debug_regression_test }}
       skip_bench: true
       skip_shellcheck: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
 
   clippy_check:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/clippy-check@v1
@@ -46,6 +47,7 @@ jobs:
 # TODO: Fix these tests, breaking due to 'stop-listener' addition
 #   test:
 #     runs-on: ubuntu-latest
+#     needs: build
 #     steps:
 #       - uses: actions/checkout@v2
 #       - run: make test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -34,6 +35,7 @@ jobs:
           path: target/release/cedana-image-streamer
 
   clippy_check:
+    name: Check
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -46,6 +48,7 @@ jobs:
 
 # TODO: Fix these tests, breaking due to 'stop-listener' addition
 #   test:
+#     name: Test
 #     runs-on: ubuntu-latest
 #     needs: build
 #     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,29 @@ on:
       - master
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt -y install protobuf-compiler
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Build cedana-image-streamer
+        run: |
+          make
+
+      - name: Persist cedana-image-streamer
+        id: persist-cedana-image-streamer
+        uses: actions/upload-artifact@v4
+        with:
+          name: streamer
+          path: target/release/cedana-image-streamer
+
   clippy_check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,6 @@ jobs:
       pull-requests: "write"
     with:
       ref: main
-      debug_build: ${{ startsWith(github.event_name, 'workflow') && inputs.debug_regression_test }}
       skip_bench: true
       skip_shellcheck: true
       skip_helper_image_push: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,3 +23,23 @@ jobs:
 #     steps:
 #       - uses: actions/checkout@v2
 #       - run: make test
+
+  regression-test:
+    name: Regression Tests
+    uses: cedana/cedana/.github/workflows/pr.yml@feature/ced-1011-reuse-regression-tests-in-cedana-gpu
+    needs: build
+    permissions:
+      contents: "read"
+      packages: "read"
+      id-token: "write"
+      pull-requests: "write"
+    with:
+      ref: feature/ced-1011-reuse-regression-tests-in-cedana-gpu
+      debug_build: ${{ startsWith(github.event_name, 'workflow') && inputs.debug_regression_test }}
+      skip_bench: true
+      skip_shellcheck: true
+      skip_helper_image_push: true
+      skip_cpu_tests: true
+      skip_streamer_tests: false
+      skip_gpu_tests: true
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,8 +52,8 @@ jobs:
 #       - uses: actions/checkout@v2
 #       - run: make test
 
-  regression-test:
-    name: Regression Tests
+  daemon-tests:
+    name: Daemon
     uses: cedana/cedana/.github/workflows/pr.yml@feature/ced-1011-reuse-regression-tests-in-cedana-gpu
     needs: build
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
PR for this repo supporting https://github.com/cedana/cedana/pull/501

Reuses the PR workflow from `cedana` repo. It looks like this:
```yml
  daemon-tests:
    name: Daemon
    uses: cedana/cedana/.github/workflows/pr.yml
    needs: build
    permissions:
      contents: "read"
      packages: "read"
      id-token: "write"
      pull-requests: "write"
    with:
      ref: main
      debug_build: ${{ startsWith(github.event_name, 'workflow') && inputs.debug_daemon_tests }}
      skip_bench: true
      skip_shellcheck: true
      skip_helper_image_push: true
      skip_cpu_tests: true
      skip_streamer_tests: false # only tests to run
      skip_gpu_tests: true
    secrets: inherit
```
It skips all the tests except the streamer ones. If you want to test against a separate branch of the daemon, just change `ref` to the branch name.