### PR TITLE
CED-2041: CRIU restore fails to start on multi-gpu workloads while streaming

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -396,7 +396,7 @@ fn send_over_chunks(
     semaphore: &Arc<Semaphore>
 ) -> Result<bool> {
     let mut res = false;
-    eprintln!("sending over chunks for: {}", filename);
+    eprintln!("sending over chunks for {}", filename);
     while let Some(file_content) = chunks.pop_front() {
         match file_content {
             FileContent::Eof => {
@@ -433,7 +433,7 @@ fn serve_img(
             .or_default()
             .push_back(buf);
     }
-    eprintln!("read small files into store: {:?}", store.keys().collect::<Vec<_>>());
+    eprintln!("read small files into store {:?}", store.keys().collect::<Vec<_>>());
 
     if !tcp_listen_remaps.is_empty() {
         if let Some(files_img) = store.remove("files.img") {
@@ -471,8 +471,12 @@ fn serve_img(
                             .or_default()
                             .push_back(buf);
                     },
-                    Err(TryRecvError::Disconnected) => { receiver_eof = true; eprintln!("[serve_img] receiver disconnected, have everything!"); break; },
-                    Err(TryRecvError::Empty) => { break; }
+                    Err(TryRecvError::Disconnected) => {
+                        receiver_eof = true;
+                        eprintln!("receiver disconnected, have everything!");
+                        break;
+                    },
+                    Err(TryRecvError::Empty) => break
                 }
             }
         }
@@ -521,12 +525,12 @@ fn serve_img(
                     Some(ref pattern) if pattern.contains('*') || pattern.is_empty() => {
                         // List all files in the image store.
                         let res = util::filter_files(&file_list, pattern);
-                        eprintln!("got a file list request result: {:?}", res);
+                        eprintln!("file list request {} result: {:?}", pattern, res);
                         client.send_file_list_reply(res)?;
                     }
                     Some(filename) => {
                         if !available_files.contains(&filename) {
-                            eprintln!("file: {} not found", &filename);
+                            eprintln!("file {} not found", &filename);
                             client.send_file_reply(false, Some(FileStatus::DoesNotExist))?; // false means that the file does not exist.
                         } else {
                             eprintln!("file request {}", &filename);
@@ -551,11 +555,10 @@ fn serve_img(
                                         // have a copy of the image file. This uses x2 the memory for an image
                                         // file. For large files like memory pages, we could very much go over
                                         // the machine memory capacity.
-                                        eprintln!("Client is requesting the image file `{}` multiple times", &filename);
-                                        bail!("Client is requesting the image file `{}` multiple times. \
-                                            This is not allowed to keep the memory usage low", &filename);
+                                        return Err(anyhow!("Client is requesting the image file `{}` multiple times. \
+                                            This is not allowed to keep the memory usage low", &filename));
                                     } else if available_files.contains(&filename) {
-                                        eprintln!("file: {} not ready, files in store: {:?}", &filename, store.keys().collect::<Vec<_>>());
+                                        eprintln!("file {} not ready", &filename);
                                         client.send_file_reply(true, Some(FileStatus::NotReady))?;
                                     }
                                 }
@@ -644,10 +647,27 @@ pub fn serve(images_dir: &Path,
     let mut img_deserializer = ImageDeserializer::new(&mut overlayed_img_store, &mut shards);
     let metadata = img_deserializer.drain_small_file_shard()?;
     let handle = spawn_serve_img(images_dir, progress_pipe, small_file_receiver, receiver, metadata, Arc::clone(&semaphore), tcp_listen_remaps);
-    img_deserializer.drain_all()?;
+    let res = img_deserializer.drain_all();
+    let mut errs: Vec<anyhow::Error> = vec![];
+    if let Err(e) = res {
+        errs.push(anyhow!("could not deserialize image: {:?}", e));
+    }
     file_sender.close_senders();
-    handle.join().map_err(|e| anyhow!("could not serve files: {:?}", e))??;
-    Ok(())
+    let server_res = handle.join().unwrap();
+    if let Err(e) = server_res {
+        errs.push(anyhow!("could not serve image: {:?}", e));
+    }
+
+    if errs.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            errs.into_iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        ))
+    }
 }
 
 /// Description of the arguments can be found in main.rs

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -462,6 +462,101 @@ fn serve_img(
 
     let epoll_capacity = 16;
     loop {
+        let mut finished = vec![];
+        for (i, (filename, pipe)) in open_pipes.iter_mut().enumerate() {
+             if let Some(chunks) = store.remove(filename.as_str()) {
+                 let sent_all = send_over_chunks(filename, chunks, pipe, &semaphore)?;
+                 if sent_all {
+                     finished.push(i);
+                 }
+             }
+        }
+
+        // remove all files we have completely sent over
+        for i in finished.into_iter().rev() {
+            open_pipes.remove(i);
+        }
+
+        if stopped && open_pipes.is_empty() {
+            break;
+        }
+
+        // handle all ready events
+        let ready_events = poller.poll_for_ready_events(epoll_capacity, EpollTimeout::try_from(1000)?)?;
+
+        for _ in 0..ready_events {
+            let Some((_, poll_obj)) = poller.get_ready_event()? else {
+                break;
+            };
+            match poll_obj {
+                PollType::Listener(listener) => { // New connection waiting, accept it
+                    let conn = listener.accept()?;
+                    poller.add(conn.as_raw_fd(), PollType::Client(conn), EpollFlags::EPOLLIN)?;
+                }
+                PollType::Client(client) => {
+                    match client.read_next_file_request()? {
+                        Some(ref filename) if filename == "stop-listener" => {
+                            // Stop accepting any new connections. Pending files will still be
+                            // processed.
+                            stopped = true;
+                            poller.remove(listener_key)?;
+                            if open_pipes.is_empty() {
+                                eprintln!("sent over all files.");
+                                break;
+                            }
+                        }
+                        // check if filename has a wildcard
+                        Some(ref pattern) if pattern.contains('*') || pattern.is_empty() => {
+                            // List all files in the image store.
+                            let res = util::filter_files(&file_list, pattern);
+                            eprintln!("file list request {} result: {:?}", pattern, res);
+                            client.send_file_list_reply(res)?;
+                        }
+                        Some(filename) => {
+                            if !available_files.contains(&filename) {
+                                eprintln!("file {} not found", &filename);
+                                client.send_file_reply(false, Some(FileStatus::DoesNotExist))?; // false means that the file does not exist.
+                            } else {
+                                eprintln!("file request {}", &filename);
+                                match store.remove(&filename) {
+                                    Some(chunks) => {
+                                        // we should not get anymore requests for the file
+                                        filenames_of_sent_files.insert(filename.clone());
+                                        client.send_file_reply(true, Some(FileStatus::Ready))?; // true means that the file exists.
+                                        let mut pipe = client.recv_pipe()?;
+                                        // Try setting the pipe capacity. Failing is okay.
+                                        let _ = pipe.set_capacity(CLIENT_PIPE_DESIRED_CAPACITY);
+                                        // send as much data as we have available right now and then
+                                        // add it to the list of fds we have that are open
+                                        let res = send_over_chunks(&filename, chunks, &mut pipe, &semaphore)?;
+                                        if !res {
+                                            open_pipes.push((filename, pipe));
+                                        }
+                                    }
+                                    None => {
+                                        if filenames_of_sent_files.contains(&filename) {
+                                            // If we keep the image file in our process, Client will also
+                                            // have a copy of the image file. This uses x2 the memory for an image
+                                            // file. For large files like memory pages, we could very much go over
+                                            // the machine memory capacity.
+                                            return Err(anyhow!("Client is requesting the image file `{}` multiple times. \
+                                                This is not allowed to keep the memory usage low", &filename));
+                                        } else if available_files.contains(&filename) {
+                                            eprintln!("file {} not ready", &filename);
+                                            client.send_file_reply(true, Some(FileStatus::NotReady))?;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        None => {
+                            // Do nothing.
+                        }
+                    }
+                }
+            }
+        }
+
         // get a chunk from receiver
         if !receiver_eof {
             loop {
@@ -481,96 +576,6 @@ fn serve_img(
             }
         }
 
-        let mut finished = vec![];
-        for (i, (filename, pipe)) in open_pipes.iter_mut().enumerate() {
-             if let Some(chunks) = store.remove(filename.as_str()) {
-                 let sent_all = send_over_chunks(filename, chunks, pipe, &semaphore)?;
-                 if sent_all {
-                     finished.push(i);
-                 }
-             }
-        }
-
-        // remove all files we have completely sent over
-        for i in finished.into_iter().rev() {
-            open_pipes.remove(i);
-        }
-
-        let obj = poller.poll(epoll_capacity, EpollTimeout::try_from(2000)?)?;
-        let Some((_, poll_obj)) = obj else {
-            if stopped && open_pipes.is_empty() {
-                eprintln!("sent over all files.");
-                break;
-            }
-            continue;
-        };
-        match poll_obj {
-            PollType::Listener(listener) => { // New connection waiting, accept it
-                let conn = listener.accept()?;
-                poller.add(conn.as_raw_fd(), PollType::Client(conn), EpollFlags::EPOLLIN)?;
-            }
-            PollType::Client(client) => {
-                match client.read_next_file_request()? {
-                    Some(ref filename) if filename == "stop-listener" => {
-                        // Stop accepting any new connections. Pending files will still be
-                        // processed.
-                        stopped = true;
-                        poller.remove(listener_key)?;
-                        if open_pipes.is_empty() {
-                            eprintln!("sent over all files.");
-                            break;
-                        }
-                    }
-                    // check if filename has a wildcard
-                    Some(ref pattern) if pattern.contains('*') || pattern.is_empty() => {
-                        // List all files in the image store.
-                        let res = util::filter_files(&file_list, pattern);
-                        eprintln!("file list request {} result: {:?}", pattern, res);
-                        client.send_file_list_reply(res)?;
-                    }
-                    Some(filename) => {
-                        if !available_files.contains(&filename) {
-                            eprintln!("file {} not found", &filename);
-                            client.send_file_reply(false, Some(FileStatus::DoesNotExist))?; // false means that the file does not exist.
-                        } else {
-                            eprintln!("file request {}", &filename);
-                            match store.remove(&filename) {
-                                Some(chunks) => {
-                                    // we should not get anymore requests for the file
-                                    filenames_of_sent_files.insert(filename.clone());
-                                    client.send_file_reply(true, Some(FileStatus::Ready))?; // true means that the file exists.
-                                    let mut pipe = client.recv_pipe()?;
-                                    // Try setting the pipe capacity. Failing is okay.
-                                    let _ = pipe.set_capacity(CLIENT_PIPE_DESIRED_CAPACITY);
-                                    // send as much data as we have available right now and then
-                                    // add it to the list of fds we have that are open
-                                    let res = send_over_chunks(&filename, chunks, &mut pipe, &semaphore)?;
-                                    if !res {
-                                        open_pipes.push((filename, pipe));
-                                    }
-                                }
-                                None => {
-                                    if filenames_of_sent_files.contains(&filename) {
-                                        // If we keep the image file in our process, Client will also
-                                        // have a copy of the image file. This uses x2 the memory for an image
-                                        // file. For large files like memory pages, we could very much go over
-                                        // the machine memory capacity.
-                                        return Err(anyhow!("Client is requesting the image file `{}` multiple times. \
-                                            This is not allowed to keep the memory usage low", &filename));
-                                    } else if available_files.contains(&filename) {
-                                        eprintln!("file {} not ready", &filename);
-                                        client.send_file_reply(true, Some(FileStatus::NotReady))?;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    None => {
-                        // Do nothing.
-                    }
-                }
-            }
-        }
     }
 
     Ok(())

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -472,7 +472,7 @@ fn serve_img(
                             .push_back(buf);
                     },
                     Err(TryRecvError::Disconnected) => { reciever_eof = true; eprintln!("[serve_img] reciever disconnected, have everything!"); break; },
-                    Err(TryRecvError::Empty) => {eprintln!("[serve_img] nothing to recieve right now!"); break; }
+                    Err(TryRecvError::Empty) => { break; }
                 }
             }
         }
@@ -546,18 +546,17 @@ fn serve_img(
                                     }
                                 }
                                 None => {
-                                    if available_files.contains(&filename) && !filenames_of_sent_files.contains(&filename) {
-                                        eprintln!("file: {} not ready", &filename);
-                                        client.send_file_reply(true, Some(FileStatus::NotReady))?;
-                                    } else {
+                                    if filenames_of_sent_files.contains(&filename) {
                                         // If we keep the image file in our process, Client will also
                                         // have a copy of the image file. This uses x2 the memory for an image
                                         // file. For large files like memory pages, we could very much go over
                                         // the machine memory capacity.
-                                        ensure!(!filenames_of_sent_files.contains(&filename) && !available_files.contains(&filename),
-                                            "Client is requesting the image file `{}` multiple times. \
+                                        eprintln!("Client is requesting the image file `{}` multiple times", &filename);
+                                        bail!("Client is requesting the image file `{}` multiple times. \
                                             This is not allowed to keep the memory usage low", &filename);
-                                        client.send_file_reply(false, Some(FileStatus::DoesNotExist))?; // false means that the file does not exist.
+                                    } else if available_files.contains(&filename) {
+                                        eprintln!("file: {} not ready, files in store: {:?}", &filename, store.keys().collect::<Vec<_>>());
+                                        client.send_file_reply(true, Some(FileStatus::NotReady))?;
                                     }
                                 }
                             }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -377,7 +377,7 @@ impl<'a, ImgStore: ImageStore> ImageDeserializer<'a, ImgStore> {
 fn spawn_serve_img(
     images_dir: &Path,
     progress_pipe: fs::File,
-    small_file_reciever: Receiver<(String, fs_parallel::FileContent)>,
+    small_file_receiver: Receiver<(String, fs_parallel::FileContent)>,
     receiver: Receiver<(String, fs_parallel::FileContent)>,
     file_list: Vec<String>,
     semaphore: Arc<Semaphore>,
@@ -385,7 +385,7 @@ fn spawn_serve_img(
 ) -> thread::JoinHandle<Result<()>> {
     let dir = images_dir.to_path_buf();
     thread::spawn(move || {
-        serve_img(&dir, progress_pipe, small_file_reciever, receiver, file_list, semaphore, tcp_listen_remaps)
+        serve_img(&dir, progress_pipe, small_file_receiver, receiver, file_list, semaphore, tcp_listen_remaps)
     })
 }
 
@@ -419,7 +419,7 @@ fn send_over_chunks(
 fn serve_img(
     images_dir: &Path,
     mut progress_pipe: fs::File,
-    small_file_reciever: Receiver<(String, fs_parallel::FileContent)>,
+    small_file_receiver: Receiver<(String, fs_parallel::FileContent)>,
     receiver: Receiver<(String, fs_parallel::FileContent)>,
     file_list: Vec<String>,
     semaphore: Arc<Semaphore>,
@@ -428,7 +428,7 @@ fn serve_img(
 {
     let mut store: HashMap<String, VecDeque<fs_parallel::FileContent>> = HashMap::new();
 
-    for (filename, buf) in small_file_reciever {
+    for (filename, buf) in small_file_receiver {
         store.entry(filename)
             .or_default()
             .push_back(buf);
@@ -456,14 +456,14 @@ fn serve_img(
 
     let mut filenames_of_sent_files = HashSet::new();
     let available_files: HashSet<String> = file_list.clone().into_iter().collect();
-    let mut reciever_eof = false;
+    let mut receiver_eof = false;
     let mut open_pipes: Vec<(String, UnixPipe)> = vec![];
     let mut stopped = false;
 
     let epoll_capacity = 16;
     loop {
-        // get a chunk from reciever
-        if !reciever_eof {
+        // get a chunk from receiver
+        if !receiver_eof {
             loop {
                 match receiver.try_recv() {
                     Ok((filename, buf)) => {
@@ -471,7 +471,7 @@ fn serve_img(
                             .or_default()
                             .push_back(buf);
                     },
-                    Err(TryRecvError::Disconnected) => { reciever_eof = true; eprintln!("[serve_img] reciever disconnected, have everything!"); break; },
+                    Err(TryRecvError::Disconnected) => { receiver_eof = true; eprintln!("[serve_img] receiver disconnected, have everything!"); break; },
                     Err(TryRecvError::Empty) => { break; }
                 }
             }
@@ -628,8 +628,8 @@ pub fn serve(images_dir: &Path,
     };
     eprintln!("memory limit for streamer: {} MB", limit);
     let semaphore = Arc::new(semaphore::Semaphore::new(limit * MB as isize));
-    let (sender, reciever) = mpsc::channel();
-    let (small_file_sender, small_file_reciever) = mpsc::channel();
+    let (sender, receiver) = mpsc::channel();
+    let (small_file_sender, small_file_receiver) = mpsc::channel();
 
     let mut file_sender = image_store::fs_parallel::FileSender::new(sender, small_file_sender, Arc::clone(&semaphore));
 
@@ -643,7 +643,7 @@ pub fn serve(images_dir: &Path,
 
     let mut img_deserializer = ImageDeserializer::new(&mut overlayed_img_store, &mut shards);
     let metadata = img_deserializer.drain_small_file_shard()?;
-    let handle = spawn_serve_img(images_dir, progress_pipe, small_file_reciever, reciever, metadata, Arc::clone(&semaphore), tcp_listen_remaps);
+    let handle = spawn_serve_img(images_dir, progress_pipe, small_file_receiver, receiver, metadata, Arc::clone(&semaphore), tcp_listen_remaps);
     img_deserializer.drain_all()?;
     file_sender.close_senders();
     handle.join().map_err(|e| anyhow!("could not serve files: {:?}", e))??;

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -419,6 +419,27 @@ fn send_over_chunks(
     Ok(res)
 }
 
+fn send_over_chunk(
+    filename: &str,
+    chunk: fs_parallel::FileContent,
+    pipe: &mut UnixPipe,
+    semaphore: &Arc<Semaphore>
+) -> Result<bool> {
+    eprintln!("sending over chunk for {}", filename);
+    match chunk {
+        FileContent::Eof => {
+            Ok(true)
+        }
+        FileContent::Content(chunk) => {
+            pipe.vmsplice_all(&chunk)?;
+            if !util::is_small_file(filename) {
+                semaphore.release(chunk.len() as isize);
+            }
+            Ok(false)
+        }
+    }
+}
+
 /// `serve_img()` serves the in-memory image store to Client.
 fn serve_img(
     images_dir: &Path,
@@ -461,32 +482,47 @@ fn serve_img(
     let mut filenames_of_sent_files = HashSet::new();
     let available_files: HashSet<String> = file_list.clone().into_iter().collect();
     let mut receiver_eof = false;
-    let mut open_pipes: Vec<(String, UnixPipe)> = vec![];
+    let mut open_pipes: HashMap<String, UnixPipe> = HashMap::new();
     let mut stopped = false;
 
     let epoll_capacity = 16;
     loop {
-        let mut finished = vec![];
-        for (i, (filename, pipe)) in open_pipes.iter_mut().enumerate() {
-             if let Some(chunks) = store.remove(filename.as_str()) {
-                 let sent_all = send_over_chunks(filename, chunks, pipe, &semaphore)?;
-                 if sent_all {
-                     finished.push(i);
-                 }
-             }
-        }
-
-        // remove all files we have completely sent over
-        for i in finished.into_iter().rev() {
-            open_pipes.remove(i);
-        }
-
         if stopped && open_pipes.is_empty() {
             break;
         }
 
+        // get a chunk from receiver
+        if !receiver_eof {
+            loop {
+                match receiver.try_recv() {
+                    Ok((filename, buf)) => {
+                        let open_pipe = open_pipes.get_mut(filename.as_str());
+                        match open_pipe {
+                            Some(mut pipe) => {
+                                let done = send_over_chunk(filename.as_str(), buf, &mut pipe, &semaphore)?;
+                                if done {
+                                    open_pipes.remove(filename.as_str());
+                                }
+                            }
+                            None => {
+                                store.entry(filename)
+                                    .or_default()
+                                    .push_back(buf);
+                            }
+                        }
+                    },
+                    Err(TryRecvError::Disconnected) => {
+                        receiver_eof = true;
+                        eprintln!("receiver disconnected, have everything!");
+                        break;
+                    },
+                    Err(TryRecvError::Empty) => break
+                }
+            }
+        }
+
         // handle all ready events
-        let ready_events = poller.poll_for_ready_events(epoll_capacity, EpollTimeout::try_from(1000)?)?;
+        let ready_events = poller.poll_for_ready_events(epoll_capacity, EpollTimeout::try_from(100)?)?;
 
         for _ in 0..ready_events {
             let Some((_, poll_obj)) = poller.get_ready_event()? else {
@@ -534,7 +570,7 @@ fn serve_img(
                                         // add it to the list of fds we have that are open
                                         let res = send_over_chunks(&filename, chunks, &mut pipe, &semaphore)?;
                                         if !res {
-                                            open_pipes.push((filename, pipe));
+                                            open_pipes.insert(filename, pipe);
                                         }
                                     }
                                     None => {
@@ -560,26 +596,6 @@ fn serve_img(
                 }
             }
         }
-
-        // get a chunk from receiver
-        if !receiver_eof {
-            loop {
-                match receiver.try_recv() {
-                    Ok((filename, buf)) => {
-                        store.entry(filename)
-                            .or_default()
-                            .push_back(buf);
-                    },
-                    Err(TryRecvError::Disconnected) => {
-                        receiver_eof = true;
-                        eprintln!("receiver disconnected, have everything!");
-                        break;
-                    },
-                    Err(TryRecvError::Empty) => break
-                }
-            }
-        }
-
     }
 
     Ok(())

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -113,7 +113,6 @@ struct ImageDeserializer<'a, ImgStore: ImageStore> {
     //    vec, and the cycle continues.
     small_file_shard: &'a mut Shard,
     small_file_seq: u64,
-    metadata: Option<Vec<String>>,
     shards: Vec<&'a mut Shard>,
     readable_shards: Vec<&'a mut Shard>,
     pending_markers: BinaryHeap<PendingMarker<'a>>,
@@ -144,7 +143,6 @@ impl<'a, ImgStore: ImageStore> ImageDeserializer<'a, ImgStore> {
         Self {
             small_file_shard: shard_iter.nth(0).unwrap(),
             small_file_seq: 0,
-            metadata: None,
             shards: shard_iter.collect(),
             readable_shards: Vec::with_capacity(num_shards - 1),
             pending_markers: BinaryHeap::with_capacity(num_shards - 1),
@@ -306,8 +304,9 @@ impl<'a, ImgStore: ImageStore> ImageDeserializer<'a, ImgStore> {
         Ok(self.readable_shards.pop())
     }
 
-    fn process_small_file_marker(&mut self, marker: image::Marker) -> Result<()> {
+    fn process_small_file_marker(&mut self, marker: image::Marker) -> Result<Option<Vec<String>>> {
         use marker::Body::*;
+        let mut metadata: Option<Vec<String>> = None;
 
         assert!(marker.seq == self.small_file_seq);
         match marker.body {
@@ -323,7 +322,7 @@ impl<'a, ImgStore: ImageStore> ImageDeserializer<'a, ImgStore> {
                     let mut metadata_bytes = Vec::with_capacity(size as usize);
                     let pipe = &mut self.small_file_shard.pipe;
                     pipe.take(size as u64).read_to_end(&mut metadata_bytes)?;
-                    self.metadata = Some(serde_json::from_slice(&metadata_bytes)?);
+                    metadata = Some(serde_json::from_slice(&metadata_bytes)?);
                 } else {
                     img_file.write_all_from_pipe(&mut self.small_file_shard.pipe, size as usize)?;
                 }
@@ -339,11 +338,12 @@ impl<'a, ImgStore: ImageStore> ImageDeserializer<'a, ImgStore> {
             }
             _ => bail!("Malformed image marker"),
         }
-        Ok(())
+        Ok(metadata)
     }
 
     // returns file metadata
     pub fn drain_small_file_shard(&mut self) -> Result<Vec<String>> {
+        let mut metadata: Option<Vec<String>> = None;
         loop {
             match pb_read_next(&mut self.small_file_shard.pipe)? {
                 None => {
@@ -351,17 +351,21 @@ impl<'a, ImgStore: ImageStore> ImageDeserializer<'a, ImgStore> {
                 }
                 Some((marker, marker_size)) => {
                     self.small_file_shard.bytes_read += marker_size as u64;
-                    self.process_small_file_marker(marker)?;
+                    match self.process_small_file_marker(marker)? {
+                        Some(meta) => {
+                            metadata = Some(meta);
+                        }
+                        None => {},
+                    }
                     self.small_file_seq += 1;
                 }
             }
         }
-        assert!(self.metadata.is_some());
-        // don't really like the clone
-        let metadata = self.metadata.as_mut().unwrap().clone();
-        // never gonna need the original now
-        self.metadata = None;
-        Ok(metadata)
+
+        match metadata {
+            None => Err(anyhow!("could not find metadata in shard")),
+            Some(meta) => Ok(meta)
+        }
     }
 
     /// Returns successfully when the image has been fully deserialized. This is our main loop.

--- a/src/image_store/fs_parallel.rs
+++ b/src/image_store/fs_parallel.rs
@@ -116,7 +116,8 @@ impl ImageFile for File {
             chunk.resize(size);
             shard_pipe.read_exact(&mut chunk)?;
             to_send -= size;
-            let _ = self.sender.send((self.filename.to_string(), FileContent::Content(chunk)));
+            self.sender.send((self.filename.to_string(), FileContent::Content(chunk)))
+                .map_err(|e| anyhow!("could not send chunk to server thread: {:?}", e))?;
         }
         Ok(())
 

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -87,11 +87,36 @@ impl<T> Poller<T> {
             if num_ready_fds == 0 {
                 return Ok(None);
             }
-
-            // We don't use a timeout (None = infinite), and we have events registered (slab is not empty)
-            // so we should have a least one fd ready.
         }
 
+        let event = self.pending_events.pop().unwrap();
+        let key = event.data() as usize;
+        let (_fd, obj) = &mut self.slab[key];
+        Ok(Some((key, obj)))
+    }
+
+    pub fn poll_for_ready_events(&mut self, capacity: usize, timeout: EpollTimeout) -> Result<usize> {
+        if self.slab.is_empty() {
+            return Ok(0);
+        }
+
+        if self.pending_events.is_empty() {
+            self.pending_events.resize(capacity, EpollEvent::empty());
+
+            let num_ready_fds = epoll_wait_no_intr(&self.epoll, &mut self.pending_events, timeout)
+                .context("Failed to wait on epoll")?;
+
+            self.pending_events.truncate(num_ready_fds);
+            return Ok(num_ready_fds)
+        }
+
+        return Ok(self.pending_events.len());
+    }
+
+    pub fn get_ready_event(&mut self) -> Result<Option<(Key, &mut T)>> {
+        if self.pending_events.is_empty() {
+            return Ok(None);
+        }
         let event = self.pending_events.pop().unwrap();
         let key = event.data() as usize;
         let (_fd, obj) = &mut self.slab[key];

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -24,9 +24,9 @@ impl Semaphore {
         *count -= want;
     }
 
-    pub fn release(&self, to_realease: isize) {
+    pub fn release(&self, to_release: isize) {
         let mut count = self.lock.lock().unwrap();
-        *count = min(*count + to_realease, self.start_val);
+        *count = min(*count + to_release, self.start_val);
         self.cvar.notify_all();
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -123,6 +123,7 @@ pub fn is_small_file(filename: &str) -> bool {
         file if file.contains("gpu") && file.contains("size") => true,
         file if file.starts_with("gpu-noctx-calls-") => true,
         file if file.starts_with("gpu-hostmem-metadata-") => true,
+        file if file.starts_with("gpu-virtmem-") => true,
         // large files
         file if Regex::new(r"^rw-layer-[0-9]+\.img$").unwrap().is_match(file) => false,
         file if file.starts_with("gpu-calls-") => false,
@@ -130,7 +131,6 @@ pub fn is_small_file(filename: &str) -> bool {
         file if file.starts_with("gpu-ctx-") => false,
         file if file.starts_with("gpu-hostmem-") => false,
         file if file.starts_with("gpu-ctxshm-") => false,
-        file if file.starts_with("gpu-virtmem-") => false,
         file if file.starts_with("gpu-envvars-") => false,
         // anything else is treated as small
         _ => true

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,7 +64,6 @@ pub fn pb_read_next<S: Read, T: Message + Default>(src: &mut S) -> Result<Option
         None => None,
         Some(mut size_buf) => {
             let size = size_buf.get_u32_le() as usize;
-            assert!(size < 10*KB, "Would read a protobuf of size >10KB. Something is wrong");
             let buf = read_bytes_next(src, size)?.ok_or_else(|| anyhow!(EOF_ERR_MSG))?;
             let bytes_read = size_of::<u32>() + size_buf.len() + buf.len();
             Some((T::decode(buf)?, bytes_read))
@@ -82,7 +81,6 @@ pub fn pb_read<S: Read, T: Message + Default>(src: &mut S) -> Result<T> {
 pub fn pb_write<S: Write, T: Message>(dst: &mut S, msg: &T) -> Result<usize> {
     let msg_size = msg.encoded_len();
     let mut buf = BytesMut::with_capacity(size_of::<u32>() + msg_size);
-    assert!(msg_size < 10*KB, "Would serialize a protobuf of size >10KB. Something is wrong");
     buf.put_u32_le(msg_size as u32);
 
     msg.encode(&mut buf).context("Failed to encode protobuf")?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -124,14 +124,17 @@ pub fn is_small_file(filename: &str) -> bool {
         file if file.starts_with("gpu-noctx-calls-") => true,
         file if file.starts_with("gpu-hostmem-metadata-") => true,
         file if file.starts_with("gpu-virtmem-") => true,
+        file if file.starts_with("gpu-envvars-") => true,
         // large files
-        file if Regex::new(r"^rw-layer-[0-9]+\.img$").unwrap().is_match(file) => false,
+        file if Regex::new(r"^rw-layer-[0-9]+\.img$").unwrap().is_match(file) => true,
+        file if Regex::new(r"^pages-[0-9]+\.img$").unwrap().is_match(file) => false,
+        file if Regex::new(r"^ghost-file-[0-9]+\.img$").unwrap().is_match(file) => true,
+        file if Regex::new(r"^tcp-stream-.*\.img$").unwrap().is_match(file) => true,
         file if file.starts_with("gpu-calls-") => false,
         file if file.starts_with("gpu-mem-") => false,
         file if file.starts_with("gpu-ctx-") => false,
         file if file.starts_with("gpu-hostmem-") => false,
         file if file.starts_with("gpu-ctxshm-") => false,
-        file if file.starts_with("gpu-envvars-") => false,
         // anything else is treated as small
         _ => true
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -124,11 +124,9 @@ pub fn is_small_file(filename: &str) -> bool {
         "runc.netns_eth0_ipv4addr" => true,
         file if file.contains("gpu") && file.contains("size") => true,
         file if file.starts_with("gpu-noctx-calls-") => true,
+        file if file.starts_with("gpu-hostmem-metadata-") => true,
         // large files
         file if Regex::new(r"^rw-layer-[0-9]+\.img$").unwrap().is_match(file) => false,
-        file if Regex::new(r"^pages-[0-9]+\.img$").unwrap().is_match(file) => false,
-        file if Regex::new(r"^ghost-file-[0-9]+\.img$").unwrap().is_match(file) => false,
-        file if Regex::new(r"^tcp-stream-.*\.img$").unwrap().is_match(file) => false,
         file if file.starts_with("gpu-calls-") => false,
         file if file.starts_with("gpu-mem-") => false,
         file if file.starts_with("gpu-ctx-") => false,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -485,7 +485,7 @@ mod load_balancing {
     // at 1MB/s. We attempt to capture a 40MB image. The choke shard should receive little
     // data compared to the other shards.
     //
-    // The first shard reserved for small files will recieve nothing.
+    // The first shard reserved for small files will receive nothing.
     // NOTE Load balancing works only when using pipes of capacity greater than 2*PAGE_SIZE.
     // We skip that test if we don't have enough pipe capacity.
     // The Rust test runner lacks the ability to skip a test at runtime, so we improvised a bit.


### PR DESCRIPTION
Related:
- https://github.com/cedana/cedana-gpu/pull/229
- https://github.com/cedana/cedana/pull/780

- remove the requirement for protobuf sizes to be less than `10KB`. For large checkpoints, file list replies are larger than 10 KB.
- Properly catch errors of the two threads so that errors in `serve_img` do not end up hidden. Makes problems like clients requesting same files multiple times easier to debug.
- Move the CRIU files to the small file shard.
- spell receive correctly.